### PR TITLE
Update Terraform Provider (VMware)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,14 +1,23 @@
 #===============================================================================================================
 # vCloud Director Provider definition, the latest version as of today is 2.4.0
 #===============================================================================================================
+
+terraform {
+  required_providers {
+    vcd = {
+      source = "vmware/vcd"
+      version = "3.5.1"
+    }
+  }
+}
+
 provider "vcd" {
-  version					= "2.3.0" // Provider version
-  user                 		= "${var.vcd_user}"
-  password             		= "${var.vcd_pass}"
-  org                  		= "${var.vcd_org}"
-  vdc                      = "${var.vcd_vdc}"
-  url                  		= "${var.vcd_url}"
+  user                 		= var.vcd_user
+  password             		= var.vcd_pass
+  org                  		= var.vcd_org
+  vdc                     = var.vcd_vdc
+  url                  		= var.vcd_url
 
   max_retry_timeout    		= "45" // Retry time for api
-  allow_unverified_ssl 		= "true"
+  allow_unverified_ssl 		= "false"
 }

--- a/main.tf
+++ b/main.tf
@@ -19,5 +19,5 @@ provider "vcd" {
   url                  		= var.vcd_url
 
   max_retry_timeout    		= "45" // Retry time for api
-  allow_unverified_ssl 		= "false"
+  allow_unverified_ssl 		= "true"
 }


### PR DESCRIPTION
Use the VMware vcd provider: https://registry.terraform.io/providers/vmware/vcd/latest 

Updated the outdated Terraform syntax (`${}`)